### PR TITLE
Add Endpoint to Retrieve the False Alarm List

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<groupId>com.mytech</groupId>
 	<artifactId>machinemonitorsystem</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<packaging>war</packaging>
+	<packaging>jar</packaging>
 	<name>machinemonitorsystem</name>
 	<description>Demo project for Machine Monitor System</description>
 	<url/>
@@ -58,6 +58,7 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-tomcat</artifactId>
 			<scope>provided</scope>
+			<!-- GFhe provided scope excludes embedded Tomcat from your JAR. -->
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -78,6 +79,10 @@
 							<artifactId>lombok</artifactId>
 						</path>
 					</annotationProcessorPaths>
+<!--					added the compilerArgs to solve http500 error -->
+					<compilerArgs>
+						<arg>-parameters</arg>
+					</compilerArgs>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/com/mytech/machinemonitorsystem/MachinemonitorsystemApplication.java
+++ b/src/main/java/com/mytech/machinemonitorsystem/MachinemonitorsystemApplication.java
@@ -2,8 +2,12 @@ package com.mytech.machinemonitorsystem;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+
+import java.util.List;
 
 @SpringBootApplication
+@ComponentScan("com.mytech.machinemonitorsystem")
 public class MachinemonitorsystemApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/mytech/machinemonitorsystem/controller/MachineMonitorController.java
+++ b/src/main/java/com/mytech/machinemonitorsystem/controller/MachineMonitorController.java
@@ -1,0 +1,25 @@
+package com.mytech.machinemonitorsystem.controller;
+
+import com.mytech.machinemonitorsystem.entity.FalseAlarmMachineSummary;
+import com.mytech.machinemonitorsystem.service.FalseAlarmService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class MachineMonitorController {
+
+    @Autowired
+    private FalseAlarmService falseAlarmService;
+
+    @GetMapping("apis/falseAlarm/{machineCode}")
+    public ResponseEntity<?> getFalseAlarms(@PathVariable int machineCode){
+        List<FalseAlarmMachineSummary> falseAlarmsForMachine = falseAlarmService.getFalseAlarmsForMachine(machineCode);
+        return ResponseEntity.ok()
+                .body(falseAlarmsForMachine);
+    }
+}

--- a/src/main/java/com/mytech/machinemonitorsystem/controller/machinemonitorcontroller.java
+++ b/src/main/java/com/mytech/machinemonitorsystem/controller/machinemonitorcontroller.java
@@ -1,5 +1,0 @@
-package com.mytech.machinemonitorsystem.controller;
-
-public class machinemonitorcontroller {
-
-}

--- a/src/main/java/com/mytech/machinemonitorsystem/repository/FalseAlarmRepository.java
+++ b/src/main/java/com/mytech/machinemonitorsystem/repository/FalseAlarmRepository.java
@@ -2,6 +2,15 @@ package com.mytech.machinemonitorsystem.repository;
 
 import com.mytech.machinemonitorsystem.entity.FalseAlarmMachineSummary;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+@Repository
 public interface FalseAlarmRepository extends JpaRepository<FalseAlarmMachineSummary,Integer > {
+    @Query(value = "SELECT f FROM FalseAlarmMachineSummary f WHERE f.machineStationCode = :machineStationCode",
+            countQuery = "SELECT count(f) FROM FalseAlarmMachineSummary f WHERE f.machineStationCode = :machineStationCode")
+    List<FalseAlarmMachineSummary> findByMachineStationCode(@Param("machineStationCode") int machineStationCode);
 }

--- a/src/main/java/com/mytech/machinemonitorsystem/service/FalseAlarmService.java
+++ b/src/main/java/com/mytech/machinemonitorsystem/service/FalseAlarmService.java
@@ -1,0 +1,22 @@
+package com.mytech.machinemonitorsystem.service;
+
+import com.mytech.machinemonitorsystem.entity.FalseAlarmMachineSummary;
+import com.mytech.machinemonitorsystem.repository.FalseAlarmRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class FalseAlarmService {
+    @Autowired
+    FalseAlarmRepository falseAlarmRepository;
+
+    public List<FalseAlarmMachineSummary> getFalseAlarmsForMachine(int machineCode){
+        if(machineCode < 0){
+            throw new IllegalArgumentException("machineCode should be greater than or equal to 0. Current:"+machineCode);
+        }
+        List<FalseAlarmMachineSummary> falseAlarms = falseAlarmRepository.findByMachineStationCode(machineCode);
+        return falseAlarms;
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -7,4 +7,9 @@ spring.datasource.password=1234fast
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+
+#logging.level.org.apache.catalina=DEBUG
+#logging.level.org.hibernate=DEBUG
+# recently  use the following two
+#logging.level.org.springframework=DEBUG
+#logging.level.root=DEBUG

--- a/src/test/java/com/mytech/machinemonitorsystem/MachinemonitorsystemApplicationTests.java
+++ b/src/test/java/com/mytech/machinemonitorsystem/MachinemonitorsystemApplicationTests.java
@@ -2,8 +2,10 @@ package com.mytech.machinemonitorsystem;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("dev")
 class MachinemonitorsystemApplicationTests {
 
 	@Test

--- a/src/test/java/com/mytech/machinemonitorsystem/repository/FalseAlarmRepositoryTest.java
+++ b/src/test/java/com/mytech/machinemonitorsystem/repository/FalseAlarmRepositoryTest.java
@@ -23,4 +23,12 @@ public class FalseAlarmRepositoryTest {
         List<FalseAlarmMachineSummary> allFalseAlarms = falseAlarmRepository.findAll();
         Assertions.assertNotNull(allFalseAlarms);
     }
+
+    @Test
+    public void testFindByStationCode(){
+        List<FalseAlarmMachineSummary> byStationCode = falseAlarmRepository.findByMachineStationCode(4);
+        Assertions.assertNotNull(byStationCode);
+        Assertions.assertEquals(12,byStationCode.size());
+        System.out.println("byStationCode:"+byStationCode.toString());
+    }
 }


### PR DESCRIPTION
1. Added endpoint to retrieve false alarm list; 2.Modified pom for packaging for war to jar,added <compilerArgs> tage; 3. Now the endpoint can run properly both in IntelliJ and via java -jar command;