### PR TITLE
Separate properties files with local vs dev,sit and prod

### DIFF
--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,13 @@
+spring.application.name=machinemonitorsystem
+
+#database related config
+spring.datasource.url=jdbc:mysql://localhost:3306/kir_server_db?serverTimezone=UTC
+spring.datasource.username=linemachine
+spring.datasource.password=1234fast
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+
+#CORS related config
+cors.allowed-origins=http://localhost:4200,http://localhost:8180
+

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,17 @@
+spring.application.name=machinemonitorsystem
+
+#database related config
+spring.datasource.url=jdbc:mysql://localhost:3306/kir_server_db?serverTimezone=UTC
+spring.datasource.username=linemachine
+spring.datasource.password=1234fast
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+
+# the following is for JNDI-which is not used for local running but for JBoss server
+# so, if run application locally in IntelliJ, comment this line
+# if build war package for JBoss via `mvn clean install`, need to keep this line
+spring.datasource.jndi-name=java:jboss/datasources/MySqlDS
+
+#CORS related config
+cors.allowed-origins=http://localhost:4200,http://localhost:8180

--- a/src/main/resources/application-sit.properties
+++ b/src/main/resources/application-sit.properties
@@ -1,0 +1,18 @@
+spring.application.name=machinemonitorsystem
+
+#database related config
+spring.datasource.url=jdbc:mysql://localhost:3306/kir_server_db?serverTimezone=UTC
+spring.datasource.username=linemachine
+spring.datasource.password=1234fast
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+
+# the following is for JNDI-which is not used for local running but for JBoss server
+# so, if run application locally in IntelliJ, comment this line
+# if build war package for JBoss via `mvn clean install`, need to keep this line
+spring.datasource.jndi-name=java:jboss/datasources/MySqlDS
+
+#CORS related config
+cors.allowed-origins=http://localhost:4200,http://localhost:8180
+


### PR DESCRIPTION
Created application-local.properties, it does not contain 'spring.datasource.jndi-name' properties, which is specifically designed for running in IntelliJ locally. 
Dev, sit and prod properties files has 'spring.datasource.jndi-name' properties, which can be used by JBoss