### PR TITLE
Add unit test for MaiService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,15 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-thymeleaf</artifactId> </dependency>
+			<artifactId>spring-boot-starter-thymeleaf</artifactId>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/com.github.stefanbirkner/system-lambda -->
+		<dependency>
+			<groupId>com.github.stefanbirkner</groupId>
+			<artifactId>system-lambda</artifactId>
+			<version>1.2.1</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/mytech/machinemonitorsystem/helper/DefaultMimeMessageHelperFactory.java
+++ b/src/main/java/com/mytech/machinemonitorsystem/helper/DefaultMimeMessageHelperFactory.java
@@ -1,0 +1,19 @@
+package com.mytech.machinemonitorsystem.helper;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+// Default implementation
+/*
+ * This implementation is used to crate MimeMessageHelper, to avoid new a MimeMessageHelper, so that in unit test MimeMessageHelper can be mocked and intercept the creating process of MimeMessage
+ * */
+@Component
+public class DefaultMimeMessageHelperFactory implements MimeMessageHelperFactory {
+
+    @Override
+    public MimeMessageHelper createMimeMessageHelper(MimeMessage mimeMessage, boolean multipart, String encoding) throws MessagingException {
+        return new MimeMessageHelper(mimeMessage, multipart, encoding);
+    }
+}

--- a/src/main/java/com/mytech/machinemonitorsystem/helper/MimeMessageHelperFactory.java
+++ b/src/main/java/com/mytech/machinemonitorsystem/helper/MimeMessageHelperFactory.java
@@ -1,0 +1,13 @@
+package com.mytech.machinemonitorsystem.helper;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+// Interface for the factory
+/*
+* This interface is used to crate MimeMessageHelper, to avoid new a MimeMessageHelper, so that in unit test MimeMessageHelper can be mocked and intercept the creating process of MimeMessage
+* */
+public interface MimeMessageHelperFactory {
+    MimeMessageHelper createMimeMessageHelper(MimeMessage mimeMessage, boolean multipart, String encoding) throws MessagingException;
+}

--- a/src/main/java/com/mytech/machinemonitorsystem/service/EmailService.java
+++ b/src/main/java/com/mytech/machinemonitorsystem/service/EmailService.java
@@ -1,5 +1,6 @@
 package com.mytech.machinemonitorsystem.service;
 
+import com.mytech.machinemonitorsystem.helper.MimeMessageHelperFactory;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,7 +9,6 @@ import org.springframework.mail.MailAuthenticationException;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
@@ -19,24 +19,54 @@ public class EmailService {
     private JavaMailSender mailSender;
     @Autowired
     private SpringTemplateEngine templateEngine;
+    @Autowired
+    private MimeMessageHelperFactory mimeMessageHelperFactory;
 
     @Value("${spring.mail.properties.mail.smtp.timeout}")
     private int smtpTimeout;
 
-//    @Async  //execute this method in a separate thread--it does not work,so have to comment it.
+    @Value("${MAIL_USERNAME}")
+    private String mailUserName;
+
+//    public int getSmtpTimeout(){
+//        return this.smtpTimeout;
+//    }
+//    public void setSmtpTimeout(int smtpTimeout){
+//        this.smtpTimeout = smtpTimeout;
+//    }
+//
+//    public String getMailUserName(){
+//        return this.mailUserName;
+//    }
+//    public void setMailUserName(String mailUserName){
+//        this.mailUserName = mailUserName;
+//    }
+    public EmailService(){}
+//    @Autowired
+    public EmailService(JavaMailSender mailSender,SpringTemplateEngine templateEngine,String mailUserName, int smtpTimeout){
+        this.mailSender = mailSender;
+        this.templateEngine = templateEngine;
+        this.mailUserName = mailUserName;
+        this.smtpTimeout = smtpTimeout;
+    }
+
+
+
+    //    @Async  //execute this method in a separate thread--it does not work,so have to comment it.
     public void sendTemplatedHtmlEmail(String[] to, String subject, String templateName, Context variables){
         try {
             String htmlContent = templateEngine.process(templateName, variables);
 //            System.out.println("Processed email content: " + htmlContent);
             MimeMessage message = mailSender.createMimeMessage();
-            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
-            helper.setFrom("${MAIL_USERNAME}");
+//            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+            MimeMessageHelper helper = mimeMessageHelperFactory.createMimeMessageHelper(message, true, "UTF-8");
+            helper.setFrom(this.mailUserName);
             helper.setTo(to);
             helper.setSubject(subject);
             helper.setText(htmlContent, true);
-            System.out.println("smtpTimeout:"+smtpTimeout);//for debug
+//            System.out.println("smtpTimeout:"+smtpTimeout);//for debug
             mailSender.send(message);
-            System.out.println("Async HTML alert email sent to " + String.join(", ", to) + " at " + System.currentTimeMillis());
+//            System.out.println("Async HTML alert email sent to " + String.join(", ", to) + " at " + System.currentTimeMillis());
 //        }catch ()
 
         } catch (MessagingException me){

--- a/src/test/java/com/mytech/machinemonitorsystem/service/MaiServiceTests.java
+++ b/src/test/java/com/mytech/machinemonitorsystem/service/MaiServiceTests.java
@@ -1,18 +1,165 @@
 package com.mytech.machinemonitorsystem.service;
 
+import com.mytech.machinemonitorsystem.helper.MimeMessageHelperFactory;
+import jakarta.mail.Address;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import org.apache.tomcat.websocket.AuthenticationException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.MailAuthenticationException;
+import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.test.context.ActiveProfiles;
+import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 
-@SpringBootTest
+import java.util.Arrays;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.github.stefanbirkner.systemlambda.SystemLambda;
+
+@ExtendWith(MockitoExtension.class)
 public class MaiServiceTests {
     @Mock
     private JavaMailSender mailSender;
-    @Autowired
+    @Mock
     private SpringTemplateEngine templateEngine;
+    @Mock
+    private MimeMessageHelperFactory mimeMessageHelperFactory;
+    @Mock
+    private MimeMessage mockedMimeMessage;
+    @InjectMocks
+    EmailService emailService;
 
-    public void testSendTemplatedHtmlEmailManualCheck(){}
+    String[] mockedTo = {"mockedEmailReceiver@gmail.com"};
+    String mockedMailUserName = "mockedMailUserName@gmail.com";
+    String mockedSubject = "mockedSubject";
+    String mockedTemplateName = "emails/alert-template";
+    Context mockedContext =  new Context();
+    MimeMessageHelper mockedMessageHelper = mock(MimeMessageHelper.class);
+    //prepare
+    String mockedHtmlContent = "Mocked htmlContent";
+
+    @BeforeEach
+    public void setup() throws MessagingException {
+//        emailService.setSmtpTimeout(20000);
+//        emailService.setMailUserName(mockedMailUserName);   //need it?--no, do not store state
+//        when(mailSender.createMimeMessage()).thenReturn(mockedMimeMessage);
+        Mockito.doReturn(mockedHtmlContent).when(templateEngine).process(mockedTemplateName,mockedContext);
+        Mockito.doReturn(mockedMimeMessage).when(mailSender).createMimeMessage();
+        Mockito.doReturn(mockedMessageHelper).when(mimeMessageHelperFactory).createMimeMessageHelper(any(MimeMessage.class),eq(true),anyString());//moved to setup()
+
+    }
+
+    //1. should send email in normal scenario
+    @Test
+    public void shouldSendEmailNormalScenario() throws MessagingException {
+
+        //given-
+        Mockito.doNothing().when(mailSender).send((MimeMessage) any());
+
+        //when
+        emailService.sendTemplatedHtmlEmail(mockedTo,mockedSubject,mockedTemplateName,mockedContext);
+        //then
+        Mockito.verify(templateEngine,Mockito.times(1)).process(eq(mockedTemplateName),eq(mockedContext));
+        Mockito.verify(mimeMessageHelperFactory,Mockito.times(1)).createMimeMessageHelper(eq(mockedMimeMessage),eq(true),eq("UTF-8"));
+        Mockito.verify(mockedMessageHelper,times(1)).setFrom((String) any());
+        Mockito.verify(mailSender,Mockito.times(1)).createMimeMessage();
+    }
+    //2.should handle checked exception:MessagingException
+    @Test
+    public void shouldHandleMessagingException() throws Exception {
+
+        //given
+        MessagingException mockedMessagingException = new MessagingException("mocked MessagingException");
+        Mockito.doThrow(mockedMessagingException).when(mockedMessageHelper).setFrom((String) any());//helper will eventually call setFrom in MimeMessage
+        //when & then
+        //here is only printed by the code under test, will check log in future
+        String printedExceptionString = SystemLambda.tapSystemOut(() -> {
+            emailService.sendTemplatedHtmlEmail(mockedTo, mockedSubject, mockedTemplateName, mockedContext);
+        });
+        //assert the exception
+        Assertions.assertTrue(printedExceptionString.contains(mockedMessagingException.getMessage().trim()));
+        //assert the interactions up to the method which throw exception
+        verify(templateEngine,times(1)).process((String) any(),any());
+        verify(mimeMessageHelperFactory,times(1)).createMimeMessageHelper(any(),eq(true),any());
+        //assert the method is called(and for sure it throw exception)
+        verify(mockedMessageHelper,times(1)).setFrom((String) any());
+    }
+    //3.should handle checked exception:MailAuthenticationException
+    @Test
+    public void shouldHandleMailAuthenticationException() throws Exception {
+        //given(arrange)
+
+        MailAuthenticationException mockedMailAuthenticationException = new MailAuthenticationException("mocked MailAuthenticationException");
+        Mockito.doThrow(mockedMailAuthenticationException)
+                .when(mailSender).send(any(MimeMessage.class));
+        //when(act) & then(assert)
+        //here is only printed by the code under test, will check log in future
+        String printedExceptionString = SystemLambda.tapSystemOut(() -> {
+            emailService.sendTemplatedHtmlEmail(mockedTo, mockedSubject, mockedTemplateName, mockedContext);
+        });
+        //assert the exception
+        Assertions.assertTrue(printedExceptionString.contains(mockedMailAuthenticationException.getMessage().trim()));
+        //assert the interactions up to the method which throw exception
+        verify(templateEngine,times(1)).process((String) any(),any());
+        verify(mimeMessageHelperFactory,times(1)).createMimeMessageHelper(any(),eq(true),any());
+        verify(mockedMessageHelper,times(1)).setFrom((String) any());
+        //assert the method is called(and for sure it throw exception)
+        verify(mailSender,times(1)).send((MimeMessage) any());
+    }
+
+    //4.should handle checked exception:MailSendException
+    @Test
+    public void shouldHandleMailSendException() throws Exception {
+        //given--arrange
+        MailSendException mockedMailSendException = new MailSendException("mocked MailSendException");
+        doThrow(mockedMailSendException).when(mailSender).send((MimeMessage) any());
+        //when&assert
+        String systemOut = SystemLambda.tapSystemOut(() -> {
+            emailService.sendTemplatedHtmlEmail(mockedTo,mockedSubject, mockedTemplateName, mockedContext);
+        });
+        Assertions.assertTrue(systemOut.contains(mockedMailSendException.getMessage().trim()));
+        //assert the interactions up to the method which throw exception
+        verify(templateEngine,times(1)).process((String) any(),any());
+        verify(mimeMessageHelperFactory,times(1)).createMimeMessageHelper(any(),eq(true),any());
+        verify(mockedMessageHelper,times(1)).setFrom((String) any());
+        //assert the method is called(and for sure it throw exception)
+        verify(mailSender,times(1)).send((MimeMessage) any());
+    }
+
+    //5.should handle unexpected exception
+    @Test
+    public void shouldHandledUnexpectedException() throws Exception {
+        //given--arrange
+        Exception mockedUnexpectedException = new RuntimeException("Mocked unexpected exception");
+        doThrow(mockedUnexpectedException).when(mailSender).send((MimeMessage) any());
+        //when&assert
+        String systemOut = SystemLambda.tapSystemOut(() -> {
+            emailService.sendTemplatedHtmlEmail(mockedTo,mockedSubject, mockedTemplateName, mockedContext);
+        });
+        Assertions.assertTrue(systemOut.contains(mockedUnexpectedException.getMessage().trim()));
+        //assert the interactions up to the method which throw exception
+        verify(templateEngine,times(1)).process((String) any(),any());
+        verify(mimeMessageHelperFactory,times(1)).createMimeMessageHelper(any(),eq(true),any());
+        verify(mockedMessageHelper,times(1)).setFrom((String) any());
+        //assert the method is called(and for sure it throw exception)
+        verify(mailSender,times(1)).send((MimeMessage) any());
+    }
 
 }


### PR DESCRIPTION
1. Added MimeMessageHelperFactory and its default implementation for unit test stubbing convenience;
2. Modified mailUserName to pick up from properties file rather than hardcoded;
3. Added uint test for MailService;